### PR TITLE
Optimize pc_guard callbacks

### DIFF
--- a/src/exports.rs
+++ b/src/exports.rs
@@ -12,6 +12,7 @@ use crate::{
         ENABLE_COUNTERS, FAZI, FAZI_INITIALIZED, INPUTS_DIR, INPUTS_EXTENSION,
     },
     options::RuntimeOptions,
+    sancov::reset_pc_guards,
     Fazi,
 };
 
@@ -301,4 +302,11 @@ pub extern "C" fn fazi_disable_cov_counters() {
 /// Re-enable inlined counters counting towards fazi coverage if previously disabled
 pub extern "C" fn fazi_enable_cov_counters() {
     ENABLE_COUNTERS.store(true, Ordering::Relaxed);
+}
+
+#[no_mangle]
+/// Reset guard variables sent in user defined callback that measures code coverage
+pub extern "C" fn fazi_reset_coverage() {
+    reset_pc_guards();
+    // TODO reset other coverage items
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(linkage)]
 #![feature(link_llvm_intrinsics)]
+#![feature(core_intrinsics)]
 #![doc = include_str!("../README.md")]
 
 /// Interesting values that can be used during mutations


### PR DESCRIPTION
Run custom_main.c with and without the shortcircuit optimization in __sanitizer_cov_trace_pc_guard and mesaure average time

with optimization: ~0.8s
without optimization: ~1.15s
no use of -fsanitize-coverage=trace-pc (counters only): ~0.8s Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: