### PR TITLE
Use official rust-protobuf dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ sha2 = "0.10"
 once_cell = "1.13"
 gettid = "0.1.2"
 paste = "1.0"
-protobuf = { version = "4.0.0-alpha.0", optional = true, path = "../rust-protobuf/protobuf" }
+protobuf = { version = "3.2", optional = true }
 
 [features]
-default = ["main_entrypoint", "hook_builtins", "protobuf"]
+default = ["hook_builtins", "protobuf"]
 main_entrypoint = []
 hook_memcmp = []
 hook_bcmp = []


### PR DESCRIPTION
Summary:
For protofuzzing a modified copy of rust-protobuf is used to generate .rs files from .proto files.

This modified copy is not needed by fazi itself, only need primitive types from original library.

Also remove `main_entrypoint` as a default feature

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: