### PR TITLE
add support to save fuzzing stats to file

### DIFF
--- a/src/exports.rs
+++ b/src/exports.rs
@@ -11,7 +11,7 @@ use sha1::Digest;
 use crate::{
     driver::{
         save_input, write_input, COMPARISON_OPERANDS, COV_THREADS, CRASHES_DIR, ENABLE_COUNTERS,
-        FAZI, FAZI_INITIALIZED, INPUTS_DIR, INPUTS_EXTENSION,
+        FAZI, FAZI_INITIALIZED, INPUTS_DIR, FAZI_STATS_FILE, INPUTS_EXTENSION,
     },
     options::RuntimeOptions,
     sancov::reset_pc_guards,
@@ -168,6 +168,23 @@ pub extern "C" fn fazi_set_crashes_dir(dir: *const libc::c_char) {
     fazi.options.crashes_dir = path;
 }
 
+#[no_mangle]
+/// Sets the fazi stats output file
+pub extern "C" fn fazi_set_stats_file(stats: *const libc::c_char) {
+    let mut fazi = FAZI
+        .get()
+        .expect("FAZI not initialized")
+        .lock()
+        .expect("could not lock FAZI");
+
+    let stats_str = unsafe { CStr::from_ptr(stats) };
+
+    let path: PathBuf = stats_str.to_string_lossy().into_owned().into();
+
+    crate::fazi::set_fazi_stats_file_path(&path);
+
+    fazi.options.stats_file = path;
+}
 #[no_mangle]
 /// Adds binary data to the Fazi dictionary
 pub extern "C" fn fazi_dictionary_add(

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,6 +4,7 @@ use clap::{Parser, Subcommand};
 
 const CRASHES_DEFAULT_DIR: &'static str = "./crashes";
 const CORPUS_DEFAULT_DIR: &'static str = "./corpus";
+const FAZI_STATS_FILE: &'static str = "./fazi_stats";
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
@@ -20,6 +21,10 @@ pub struct RuntimeOptions {
     /// Location at which crashing inputs will be saved
     #[clap(long, default_value = CRASHES_DEFAULT_DIR)]
     pub crashes_dir: PathBuf,
+
+    /// Location at which fazi stats will be saved
+    #[clap(long, default_value = FAZI_STATS_FILE)]
+    pub stats_file: PathBuf,
 
     /// The maximum number of times to mutate a single input before moving on
     /// to another.
@@ -65,6 +70,7 @@ impl Default for RuntimeOptions {
         Self {
             corpus_dir: CORPUS_DEFAULT_DIR.into(),
             crashes_dir: CRASHES_DEFAULT_DIR.into(),
+            stats_file: FAZI_STATS_FILE.into(),
             max_mutation_depth: 15,
             len_control: 100,
             min_input_len: 0,


### PR DESCRIPTION
for testing, this PR also update the example harness to be macos compatible.

```
~/s/fazi_fork main• 1.4s ❱ ./a.out
Setting death callback
corpus: "corpus"
crashes: "crashes"
fazi stats path: "fazi_stats.json"
old coverage: 0, new coverage: 4, mutations: 0
Saving corpus input to "corpus/input-049b3d8e028a7f3cd00807dc8c741603250809ec"
old coverage: 4, new coverage: 6, mutations: 7
Saving corpus input to "corpus/input-a3f5465c4802583ca7ff92063600e7b5a520063c"
old coverage: 6, new coverage: 8, mutations: 2
Saving corpus input to "corpus/input-290bd43e78d2ebcd82a1ad9afdb3592122b97901"
old coverage: 8, new coverage: 9, mutations: 7
Saving corpus input to "corpus/input-ba21495526703e7943025a64e185f1925e822849"
100000 iterations in : 0.268819s
100000 iterations in : 0.263875s
100000 iterations in : 0.264496s
100000 iterations in : 0.255644s
100000 iterations in : 0.264146s
100000 iterations in : 0.262001s
100000 iterations in : 0.275808s
100000 iterations in : 0.263917s
100000 iterations in : 0.263245s
100000 iterations in : 0.264956s
100000 iterations in : 0.274066s
100000 iterations in : 0.264946s
100000 iterations in : 0.263691s
100000 iterations in : 0.261909s
100000 iterations in : 0.267489s
100000 iterations in : 0.261394s
100000 iterations in : 0.258873s
100000 iterations in : 0.259488s
100000 iterations in : 0.260185s
100000 iterations in : 0.262639s
100000 iterations in : 0.260783s
100000 iterations in : 0.261493s
100000 iterations in : 0.264575s
100000 iterations in : 0.261167s
100000 iterations in : 0.259663s
100000 iterations in : 0.260230s
100000 iterations in : 0.263554s
100000 iterations in : 0.260042s
100000 iterations in : 0.279403s
100000 iterations in : 0.274429s
100000 iterations in : 0.263945s
100000 iterations in : 0.274246s
100000 iterations in : 0.267184s
100000 iterations in : 0.267735s
100000 iterations in : 0.266446s
100000 iterations in : 0.260664s
100000 iterations in : 0.265569s
stats: FaziStats { iterations: 3758351, corpus: 4, current_mutation_depth: 10, current_max_input_len: 38074, coverage: 9, last_update_time: 1725425654 }
saving stats to: fazi_stats.json
```