### PR TITLE
add support to save asan crash to file

### DIFF
--- a/examples/custom_main.c
+++ b/examples/custom_main.c
@@ -35,6 +35,7 @@ void fazi_reset_coverage();
 void fazi_next_recoverage_testcase(char** data, size_t* size);
 void fazi_restore_inputs();
 void fazi_add_coverage_current_thread();
+void fazi_set_sanitizer_report_path(const char* path);
 
 unsigned char answer[] = {0xde, 0xad, 0xbe, 0xef};
 
@@ -47,7 +48,7 @@ int test_func(const unsigned char *data, size_t len) {
         // printf("data matched!\n");
         // artificially crash program
         char *p = 0x13371337;
-        // *p = 0xff;
+        *p = 0xff;
         return 1;
     }
     return 0;
@@ -87,6 +88,7 @@ int main() {
     fazi_init_signal_handler();
     fazi_set_corpus_dir("corpus");
     fazi_set_crashes_dir("crashes");
+    fazi_set_sanitizer_report_path("crashes/asan_crash");
     fazi_set_stats_file("fazi_stats.json");
     fazi_restore_inputs();
     fazi_enable_rust_backtrace();

--- a/src/exports.rs
+++ b/src/exports.rs
@@ -45,6 +45,18 @@ pub extern "C" fn fazi_init_signal_handler() {
 }
 
 #[no_mangle]
+/// Sets up custom sanitizer report path
+pub extern "C" fn fazi_set_sanitizer_report_path(path: *const libc::c_char) {
+    let fazi = FAZI
+        .get()
+        .expect("FAZI not initialized")
+        .lock()
+        .expect("could not lock FAZI");
+
+    fazi.setup_sanitizer_report_path(path as *const char);
+}
+
+#[no_mangle]
 /// Sets up Fazi's corpus/crash artifact extension
 pub extern "C" fn fazi_set_artifact_extension(extension: *const libc::c_char) {
     let mut fazi = FAZI

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -2,6 +2,7 @@ use std::{
     panic::{self},
     path::Path,
     thread,
+    ffi::CStr,
 };
 
 use libc::{SIGABRT, SIGSEGV};
@@ -11,6 +12,7 @@ use signal_hook::iterator::Signals;
 use crate::{
     driver::{handle_crash, save_input, CRASHES_DIR, INPUTS_DIR, INPUTS_EXTENSION, LAST_INPUT},
     weak_imports::sanitizer_set_death_callback_fn,
+    weak_imports::sanitizer_set_report_path_fn,
     Fazi,
 };
 
@@ -50,6 +52,15 @@ impl<R: Rng> Fazi<R> {
 
             death_callback();
         }));
+    }
+
+    pub fn setup_sanitizer_report_path(&self, report_path: *const char) {
+    	if let Some(set_report_path) = sanitizer_set_report_path_fn() {
+            unsafe {
+	        eprintln!("Setting sanitizer report path {}", CStr::from_ptr(report_path as *const i8).to_str().unwrap());
+                set_report_path(report_path);
+            }
+        }
     }
 }
 

--- a/src/weak_imports.rs
+++ b/src/weak_imports.rs
@@ -26,6 +26,16 @@ pub(crate) fn libfuzzer_initialize_fn() -> Option<
     }
 }
 
+pub(crate) fn sanitizer_set_report_path_fn(
+) -> Option<unsafe extern "C" fn(*const char) -> std::ffi::c_void> {
+    #[allow(non_snake_case)]
+    {
+        weak!(fn __sanitizer_set_report_path(*const char) -> std::ffi::c_void);
+
+        __sanitizer_set_report_path.get()
+    }
+}
+
 pub(crate) fn sanitizer_set_death_callback_fn(
 ) -> Option<unsafe extern "C" fn(extern "C" fn()) -> std::ffi::c_void> {
     #[allow(non_snake_case)]


### PR DESCRIPTION
title. 

```
~/s/fazi_fork fazi-logging• ❱ ./a.out
Setting death callback
corpus: "corpus"
crashes: "crashes"
Setting sanitizer report path crashes/asan_crash
fazi stats path: "fazi_stats.json"
old coverage: 0, new coverage: 4, mutations: 0
Saving corpus input to "corpus/input-049b3d8e028a7f3cd00807dc8c741603250809ec"
old coverage: 4, new coverage: 6, mutations: 4
Saving corpus input to "corpus/input-73867766116ad02a77b821ef49881fe44ee22442"
old coverage: 6, new coverage: 8, mutations: 2
Saving corpus input to "corpus/input-e87e9aef1eaa408568ca6998c5621a5c4e4285af"
AddressSanitizer:DEADLYSIGNAL
Death callback called
Saving crash to "crashes/crash-cbbe63941956d4d96cf74cf4fec529fc1d896b67"
fish: Job 1, './a.out' terminated by signal SIGABRT (Abort)
```

can see the crash report saved to the specified folder

```
~/s/fazi_fork fazi-logging• | 134 ❱ cat crashes/asan_crash.93865
=================================================================
==93865==ERROR: AddressSanitizer: SEGV on unknown address 0x000013371337 (pc 0x000100e18e58 bp 0x00016efeb3d0 sp 0x00016efeb2b0 T0)
==93865==The signal is caused by a WRITE memory access.
    #0 0x100e18e58 in test_func custom_main.c:51
    #1 0x100e19560 in main custom_main.c:136
    #2 0x18c703150  (<unknown module>)

==93865==Register values:
 x[0] = 0x0000000000000000   x[1] = 0x000000016efeb218   x[2] = 0x0000000000000008   x[3] = 0x0000000104f2e810
 x[4] = 0x0000000104f2e8c0   x[5] = 0x0000000000000001   x[6] = 0x000000016e7f0000   x[7] = 0x0000000000000001
 x[8] = 0x00000000000000ff   x[9] = 0x0000000013371337  x[10] = 0x00000001010001e8  x[11] = 0x0000000000000002
x[12] = 0x0000000000000001  x[13] = 0xffffffffffffffff  x[14] = 0x0000000104501948  x[15] = 0x0000000000000001
x[16] = 0x000000018ca88a44  x[17] = 0x00000001019fc758  x[18] = 0x0000000000000000  x[19] = 0x000000016efeb440
x[20] = 0x0000000100e1914c  x[21] = 0x000000016efeb540  x[22] = 0x0000000101515910  x[23] = 0x000000016efeb570
x[24] = 0x000000016efeb600  x[25] = 0x000000018c777e0b  x[26] = 0x0000000000000000  x[27] = 0x0000000000000000
x[28] = 0x0000000000000000     fp = 0x000000016efeb3d0     lr = 0x0000000100e18ddc     sp = 0x000000016efeb2b0
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV custom_main.c:51 in test_func
==93865==ABORTING
```