### PR TITLE
Fix to __sanitizer_cov_trace_pc_guard

### DIFF
--- a/src/sancov.rs
+++ b/src/sancov.rs
@@ -162,7 +162,7 @@ fn should_record_coverage() -> bool {
 }
 
 #[no_mangle]
-extern "C" fn __sanitizer_cov_trace_pc_guard(guard: *mut usize) {
+extern "C" fn __sanitizer_cov_trace_pc_guard(guard: *mut u32) {
     // This callback is executed everywhere in code instrumented with `-fsanitize-coverage=trace-pc-guard`
     // Do quick checks first for optimization
     unsafe {


### PR DESCRIPTION
This needs to be a u32, else get alignment issues

2025-08-06 09:38:40.422   899-899   wrap.sh                 pid-899                              I  thread '<unnamed>' panicked at ...../src/sancov.rs:170:36:
2025-08-06 09:38:40.422   899-899   wrap.sh                 pid-899                              I  misaligned pointer dereference: address must be a multiple of 0x8 but is 0x71faab6194

https://clang.llvm.org/docs/SanitizerCoverage.html

